### PR TITLE
Handle "not connected" errors

### DIFF
--- a/stream-server.js
+++ b/stream-server.js
@@ -35,10 +35,12 @@ socketServer.on('connection', function(socket) {
 
 socketServer.broadcast = function(data, opts) {
 	for( var i in this.clients ) {
-		if (this.clients[i].readyState == 1)
+		if (this.clients[i].readyState == 1) {
 			this.clients[i].send(data, opts);
-		else
-			this.emit("error", "not connected");
+		}
+		else {
+			console.log( 'Error: Client ('+i+') not connected.' );
+		}
 	}
 };
 


### PR DESCRIPTION
This stops the script from attempting to write to closed websockets, which causes websocket.js to throw an error and exit the process. Instead it emits an error and continues.
