### PR TITLE
Added a bower manifest

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,14 @@
+{
+  "name": "jsmpeg",
+  "version": "1.0.0",
+  "authors": [
+    "Dominic Szablewski"
+  ],
+  "description": "jsmpeg library",
+  "main": "jsmpg.js",
+  "keywords": [
+    "jsmpeg"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/phoboslab/jsmpeg"
+}


### PR DESCRIPTION
Bower is a package manager for frontend dependencies.  I've added a bower manifest, which allows you to run "bower register" to register jsmpeg in bower's repositories.
