### PR TITLE
must call response.end() on each request

### DIFF
--- a/stream-server.js
+++ b/stream-server.js
@@ -59,6 +59,15 @@ var streamServer = require('http').createServer( function(request, response) {
 			'Stream Connected: ' + request.socket.remoteAddress + 
 			':' + request.socket.remotePort + ' size: ' + width + 'x' + height
 		);
+
+		request.on('error', function(){
+ 			response.end();
+		});
+
+		request.on('end', function(){
+ 			response.end();
+		});
+
 		request.on('data', function(data){
 			socketServer.broadcast(data, {binary:true});
 		});


### PR DESCRIPTION
I believe the stream server leaks memory when the ffmpeg process stops since response.end() is never called. 

Attaching a request 'end' event handler. https://nodejs.org/api/stream.html#stream_event_end

https://nodejs.org/api/http.html#http_response_end_data_encoding_callback
