### PR TITLE
Add WebRTC DataChannel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ var client = new WebSocket( 'ws://example.com:8084/' );
 var player = new jsmpeg(client, {canvas:canvas});
 ```
 
+Also, you can pass a RTCDataChannel connection when you use WebRTC:
+
+```javascript
+var pc = new PeerConnection();
+var dc = pc.createDataChannel("my channel");
+var player = new jsmpeg(dc, {canvas:canvas});
+```
+
 ###Stream Recording###
 
 To record an MPEG stream clientside in the browser jsmpeg provides the `.startRecording(cb)` and `.stopRecording()` methods. `.stopRecording()` returns a `Blob` object that can be used to create a download link.

--- a/jsmpg.js
+++ b/jsmpg.js
@@ -14,7 +14,10 @@
 // Inspired by "MPEG Decoder in Java ME" by Nokia:
 // http://www.developer.nokia.com/Community/Wiki/MPEG_decoder_in_Java_ME
 
-
+var implementSocketInterface = function(s) {
+	return s.onopen && s.onmessage && s.onclose && s.onclose;
+}
+		  
 var requestAnimFrame = (function(){
 	return window.requestAnimationFrame ||
 		window.webkitRequestAnimationFrame ||
@@ -51,7 +54,7 @@ var jsmpeg = window.jsmpeg = function( url, opts ) {
 		this.renderFrame = this.renderFrame2D;
 	}
 
-	if( url instanceof WebSocket ) {
+	if( implementSocketInterface(url) ) {
 		this.client = url;
 		this.client.onopen = this.initSocketClient.bind(this);
 	}


### PR DESCRIPTION
RTCDataChannel just like WebSocket, can be easily supported too. When someone like to make a video meeting using MPEG streaming, it may be useful.