### PR TITLE
Fix canvas.toDataURL yielding blank image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The `options` argument to the `jsmpeg()` supports the following properties:
 - `autoplay` whether playback should start automatically after loading
 - `loop` whether playback is looped
 - `seekable` whether a seek-index is build during load time; neccessary for `seekToFrame` and `seekToTime` methods
+- `progressiveThrottled` whether to throttle downloading chunks until they're needed for playback. Requires `progressive`; default `false`.
 - `onload` a function that's called once, after the .mpg file has been completely loaded
 - `ondecodeframe` a function that's called after every frame that's decoded and rendered to the canvas
 - `onfinished` a function that's called when playback ends

--- a/jsmpg.js
+++ b/jsmpg.js
@@ -18,6 +18,7 @@ var jsmpeg = window.jsmpeg = function( url, opts ) {
 	this.wantsToPlay = this.autoplay;
 	this.loop = !!opts.loop;
 	this.seekable = !!opts.seekable;
+  	this.preserveDrawingBuffer = !!opts.preserveDrawingBuffer;
 	this.externalLoadCallback = opts.onload || null;
 	this.externalDecodeCallback = opts.ondecodeframe || null;
 	this.externalFinishedCallback = opts.onfinished || null;
@@ -928,7 +929,7 @@ jsmpeg.prototype.initWebGL = function() {
 
 	// attempt to get a webgl context
 	try {
-		var options = { preserveDrawingBuffer: true };
+    		var options = { preserveDrawingBuffer: this.preserveDrawingBuffer };
 		gl = this.gl = this.canvas.getContext('webgl', options) || this.canvas.getContext('experimental-webgl', options);
 	} catch (e) {
 		return false;

--- a/jsmpg.js
+++ b/jsmpg.js
@@ -18,7 +18,7 @@ var jsmpeg = window.jsmpeg = function( url, opts ) {
 	this.wantsToPlay = this.autoplay;
 	this.loop = !!opts.loop;
 	this.seekable = !!opts.seekable;
-  this.preserveDrawingBuffer = !!opts.preserveDrawingBuffer;
+	this.preserveDrawingBuffer = !!opts.preserveDrawingBuffer;
 	this.externalLoadCallback = opts.onload || null;
 	this.externalDecodeCallback = opts.ondecodeframe || null;
 	this.externalFinishedCallback = opts.onfinished || null;
@@ -929,7 +929,7 @@ jsmpeg.prototype.initWebGL = function() {
 
 	// attempt to get a webgl context
 	try {
-    var options = { preserveDrawingBuffer: this.preserveDrawingBuffer };
+		var options = { preserveDrawingBuffer: this.preserveDrawingBuffer };
 		gl = this.gl = this.canvas.getContext('webgl', options) || this.canvas.getContext('experimental-webgl', options);
 	} catch (e) {
 		return false;

--- a/jsmpg.js
+++ b/jsmpg.js
@@ -18,7 +18,7 @@ var jsmpeg = window.jsmpeg = function( url, opts ) {
 	this.wantsToPlay = this.autoplay;
 	this.loop = !!opts.loop;
 	this.seekable = !!opts.seekable;
-  	this.preserveDrawingBuffer = !!opts.preserveDrawingBuffer;
+  this.preserveDrawingBuffer = !!opts.preserveDrawingBuffer;
 	this.externalLoadCallback = opts.onload || null;
 	this.externalDecodeCallback = opts.ondecodeframe || null;
 	this.externalFinishedCallback = opts.onfinished || null;
@@ -929,7 +929,7 @@ jsmpeg.prototype.initWebGL = function() {
 
 	// attempt to get a webgl context
 	try {
-    		var options = { preserveDrawingBuffer: this.preserveDrawingBuffer };
+    var options = { preserveDrawingBuffer: this.preserveDrawingBuffer };
 		gl = this.gl = this.canvas.getContext('webgl', options) || this.canvas.getContext('experimental-webgl', options);
 	} catch (e) {
 		return false;

--- a/jsmpg.js
+++ b/jsmpg.js
@@ -928,7 +928,8 @@ jsmpeg.prototype.initWebGL = function() {
 
 	// attempt to get a webgl context
 	try {
-		gl = this.gl = this.canvas.getContext('webgl') || this.canvas.getContext('experimental-webgl');
+		var options = { preserveDrawingBuffer: true };
+		gl = this.gl = this.canvas.getContext('webgl', options) || this.canvas.getContext('experimental-webgl', options);
 	} catch (e) {
 		return false;
 	}


### PR DESCRIPTION
Added `preserveDrawingBuffer` as option to getContext for webgl.
Tested in Chrome and IE11

Can be tested as follows:

1. Go to http://phoboslab.org/log/2013/05/mpeg1-video-decoder-in-javascript
2. Run the following snippet in the console
3. Scroll to the bottom and see the blank image.

```javascript
var img = document.createElement('img');
img.src = player.canvas.toDataURL('image/webp', 0.7)
img.style.border = '1px solid red';
document.body.appendChild(img);
```
