### PR TITLE
Added playback ready callback for progressive loading option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The `options` argument to the `jsmpeg()` supports the following properties:
 - `loop` whether playback is looped
 - `seekable` whether a seek-index is build during load time; neccessary for `seekToFrame` and `seekToTime` methods
 - `onload` a function that's called once, after the .mpg file has been completely loaded
+- `onplaybackready` a function for the progressive option which is called once when the first chunk is loaded and playback is ready
 - `ondecodeframe` a function that's called after every frame that's decoded and rendered to the canvas
 - `onfinished` a function that's called when playback ends
 

--- a/jsmpg.js
+++ b/jsmpg.js
@@ -9,6 +9,7 @@ var jsmpeg = window.jsmpeg = function(url, opts) {
 	this.loop = !!opts.loop;
 	this.seekable = !!opts.seekable;
 	this.externalLoadCallback = opts.onload || null;
+	this.externalPlaybackReadyCallback = opts.onplaybackready || null;
 	this.externalDecodeCallback = opts.ondecodeframe || null;
 	this.externalFinishedCallback = opts.onfinished || null;
 
@@ -481,6 +482,7 @@ jsmpeg.prototype.loadNextChunk = function() {
 };
 
 jsmpeg.prototype.canPlayThrough = false;
+jsmpeg.prototype.playbackReadyCallbackFired = false;
 
 jsmpeg.prototype.progressiveLoadCallback = function(data) {
 	this.chunkIsLoading = false;
@@ -515,6 +517,11 @@ jsmpeg.prototype.progressiveLoadCallback = function(data) {
 		for (frames = 0; this.findStartCode(START_PICTURE) !== BitReader.NOT_FOUND; frames++) {}
 		this.buffer.index = currentIndex;
 		bytesPerSecondPlayed = bytes.length/(frames / this.pictureRate);
+
+		if (this.externalPlaybackReadyCallback && ! this.playbackReadyCallbackFired) {
+			this.playbackReadyCallbackFired = true;
+			this.externalPlaybackReadyCallback( this );
+		}
 	}
 	
 	


### PR DESCRIPTION
I needed a callback when the first chunk was loaded from the new progressive loading option, so I can manually start playback together with an audio element instead of relying on autoplay. 

This is my first PR, let me know if I could have done something better. 