### PR TITLE
Add support for custom source

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -3,7 +3,11 @@ JSMpeg.Player = (function(){ "use strict";
 var Player = function(url, options) {
 	this.options = options || {};
 
-	if (url.match(/^wss?:\/\//)) {
+	if (options.source) {
+		this.source = new options.source(url, options);
+		options.streaming = !!this.source.streaming;
+	}
+	else if (url.match(/^wss?:\/\//)) {
 		this.source = new JSMpeg.Source.WebSocket(url, options);
 		options.streaming = true;
 	}


### PR DESCRIPTION
I added custom source support. The following code is example.

```javascript
// Constructor
function CustomSource(url, options) {
  this.progress = 0;
  this.established = false; // set true when established
  this.streaming = false; // or true
  this.completed = false; // set true when completed
}

// Interfaces
CustomSource.prototype.connect = function(demuxer) { /* snip */ };
CustomSource.prototype.start = function() { /* snip */};
CustomSource.prototype.resume = function(secondsHeadroom) { /* snip */};
CustomSource.prototype.abort = function() { /* snip */ };

// Create a player with custom source
var player = new JSMpeg.Player(url, { source: MyContomSource });
```