### PR TITLE
Enable WebSocket to accept sub-protocols

### DIFF
--- a/src/websocket.js
+++ b/src/websocket.js
@@ -2,6 +2,7 @@ JSMpeg.Source.WebSocket = (function(){ "use strict";
 
 var WSSource = function(url, options) {
 	this.url = url;
+	this.options = options;
 	this.socket = null;	
 
 	this.callbacks = {connect: [], data: []};
@@ -34,7 +35,7 @@ WSSource.prototype.start = function() {
 	this.progress = 0;
 	this.established = false;
 
-	this.socket = new WebSocket(this.url);
+	this.socket = new WebSocket(this.url, this.options.protocols || '');
 	this.socket.binaryType = 'arraybuffer';
 	this.socket.onmessage = this.onMessage.bind(this);
 	this.socket.onopen = this.onOpen.bind(this);


### PR DESCRIPTION
Add opportunity to pass sub-protocols to construct `WebSocket`. Ref: https://developer.mozilla.org/en-US/docs/Web/API/WebSocket