### PR TITLE
Fix for subprotocol: some browsers reject empty string

### DIFF
--- a/src/websocket.js
+++ b/src/websocket.js
@@ -35,7 +35,7 @@ WSSource.prototype.start = function() {
 	this.progress = 0;
 	this.established = false;
 
-	this.socket = new WebSocket(this.url, this.options.protocols || '');
+	this.socket = new WebSocket(this.url, this.options.protocols);
 	this.socket.binaryType = 'arraybuffer';
 	this.socket.onmessage = this.onMessage.bind(this);
 	this.socket.onopen = this.onOpen.bind(this);


### PR DESCRIPTION
See https://github.com/phoboslab/jsmpeg/pull/133#commitcomment-21269588