### PR TITLE
Unlock audio in Iphone/Ipad devices

### DIFF
--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -107,7 +107,7 @@ WebAudioOut.prototype.unlock = function(callback) {
 	var source = this.context.createBufferSource();
 	source.buffer = buffer;
 	source.connect(this.destination);
-	source.start(0);
+	source.noteOn(0);
 
 	setTimeout(this.checkIfUnlocked.bind(this, source, 0), 0);
 };


### PR DESCRIPTION
The unlock function wasn't working and after some research I found this solution:

https://paulbakaus.com/tutorials/html5/web-audio-on-ios/

Just changed the `source.start(0)` to `source.noteOn(0)` and it worked.