### PR TITLE
Support ws3

### DIFF
--- a/websocket-relay.js
+++ b/websocket-relay.js
@@ -24,12 +24,12 @@ var STREAM_SECRET = process.argv[2],
 // Websocket Server
 var socketServer = new WebSocket.Server({port: WEBSOCKET_PORT, perMessageDeflate: false});
 socketServer.connectionCount = 0;
-socketServer.on('connection', function(socket) {
+socketServer.on('connection', function(socket, upgradeReq) {
 	socketServer.connectionCount++;
 	console.log(
 		'New WebSocket Connection: ', 
-		socket.upgradeReq.socket.remoteAddress,
-		socket.upgradeReq.headers['user-agent'],
+		(upgradeReq || socket.upgradeReq).socket.remoteAddress,
+		(upgradeReq || socket.upgradeReq).headers['user-agent'],
 		'('+socketServer.connectionCount+' total)'
 	);
 	socket.on('close', function(code, message){


### PR DESCRIPTION
The upgradeReq property was moved from the socket to the connection event to reduce memory use.

https://github.com/websockets/ws/releases/tag/3.0.0