### PR TITLE
Fix for uncaught error of destroy method

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -113,8 +113,10 @@ Player.prototype.stop = function(ev) {
 Player.prototype.destroy = function() {
 	this.pause();
 	this.source.destroy();
-	this.renderer.destroy();
-	this.audioOut.destroy();
+	if(this.renderer)
+		this.renderer.destroy();
+	if(this.audioOut)
+		this.audioOut.destroy();
 };
 
 Player.prototype.seek = function(time) {


### PR DESCRIPTION
patch for #174
In the presence of options `video: false` or `audio: false`, `destroy()` method of player instance throws an error as

```js
Uncaught TypeError: Cannot read property 'destroy' of undefined
    at Player.destroy (jsmpeg.min.js:formatted:264)

```