### PR TITLE
Delay the `JSMpeg.CreateVideoElements` call 'till after the script has loaded

### DIFF
--- a/src/jsmpeg.js
+++ b/src/jsmpeg.js
@@ -97,7 +97,9 @@ var JSMpeg = {
 
 // Automatically create players for all found <div class="jsmpeg"/> elements.
 if (document.readyState === 'complete') {
-	JSMpeg.CreateVideoElements();
+	setTimeout(function() {
+		JSMpeg.CreateVideoElements();
+	});
 }
 else {
 	document.addEventListener('DOMContentLoaded', JSMpeg.CreateVideoElements);


### PR DESCRIPTION
I couldn't find an issue about it, so I guess nobody has come across this issue yet.

When you load JSMpeg on-the-fly, it performs a `JSMpeg.CreateVideoElements();` call because `document.readyState === 'complete'`

That's nice and all, but it does that before all the other code has run, so `JSMpeg.Player` and all is still `null`.

Wrapping it in a simple `setTimeout` fixes that.