### PR TITLE
Add `Stream` support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,6 +7,7 @@ uglifyjs \
 	src/ajax.js \
 	src/ajax-progressive.js \
 	src/websocket.js \
+	src/stream.js \
 	src/ts.js \
 	src/decoder.js \
 	src/mpeg1.js \

--- a/src/player.js
+++ b/src/player.js
@@ -7,6 +7,10 @@ var Player = function(url, options) {
 		this.source = new options.source(url, options);
 		options.streaming = !!this.source.streaming;
 	}
+	else if (url && typeof url.pipe == 'function') {
+		this.source = new JSMpeg.Source.Stream(url, options);
+		options.streaming = true;
+	}
 	else if (url.match(/^wss?:\/\//)) {
 		this.source = new JSMpeg.Source.WebSocket(url, options);
 		options.streaming = true;

--- a/src/stream.js
+++ b/src/stream.js
@@ -1,0 +1,63 @@
+JSMpeg.Source.Stream = (function(){ "use strict";
+
+var StreamSource = function(stream, options) {
+	this.stream = stream;
+	this.destination = null;
+
+	this.completed = false;
+	this.established = false;
+	this.progress = 0;
+
+	// Streaming is obiously true when using a stream
+	this.streaming = true;
+};
+
+StreamSource.prototype.connect = function(destination) {
+	this.destination = destination;
+};
+
+StreamSource.prototype.setStream = function(stream) {
+	if (this.stream) {
+		this.stream.destroy();
+	}
+
+	this.stream = stream;
+	this.start();
+};
+
+StreamSource.prototype.start = function() {
+
+	var that = this;
+
+	if (!this.stream) {
+		return;
+	}
+
+	this.stream.on('data', function onData(chunk) {
+		that.onLoad(chunk);
+	});
+};
+
+StreamSource.prototype.resume = function(secondsHeadroom) {
+	// Nothing to do here
+};
+
+StreamSource.prototype.destroy = function() {
+	if (this.stream) {
+		this.stream.destroy();
+	}
+};
+
+StreamSource.prototype.onLoad = function(data) {
+	this.established = true;
+	this.completed = true;
+	this.progress = 1;
+
+	if (this.destination) {
+		this.destination.write(data);
+	}
+};
+
+return StreamSource;
+
+})();


### PR DESCRIPTION
Code needs a little work, but I'd love to know what you'd think about adding a Stream source.

It might be fairly trivial to add your own custom sources, but it would be nice to be able to do:

```javascript
var player = new JSMpeg.Player(my_stream);
```

or

```javascript
var player = new JSMpeg.Player(null, {source: JSMpeg.Source.Stream});
player.source.setStream(my_stream);
```

This would add support for streams from `browserify` or `socket.io-stream`.

There's also a native stream standard in the works for Javascript, it's currently only supported in Chrome but it might be interesting to incorporate that, too?

And by the way: great job on the rewrite. Using a TS makes much more sense and I'm finally rid of annoying artifacts.


