### PR TITLE
Fix for Emscripten latest version

### DIFF
--- a/src/wasm-module.js
+++ b/src/wasm-module.js
@@ -27,9 +27,9 @@ WASM.prototype.loadFromBuffer = function(buffer, callback) {
 	this.memory = new WebAssembly.Memory({initial: 256});
 	var env = {
 		memory: this.memory,
-		memoryBase: 0,
+		__memory_base: 0,
 		table: new WebAssembly.Table({initial: this.moduleInfo.tableSize, element: 'anyfunc'}),
-		tableBase: 0,
+		__table_base: 0,
 		abort: this.c_abort.bind(this),
 		___assert_fail: this.c_assertFail.bind(this),
 		_sbrk: this.c_sbrk.bind(this)


### PR DESCRIPTION
Change wasm module to accomodate emscripten changes.
From changelog:
v1.38.18: 11/08/2018
--------------------
 - Wasm dynamic linking: Rename `tableBase/memoryBase` to
   `__table_base/__memory_base` (#7467)