### PR TITLE
Fix memory leaks

### DIFF
--- a/src/webgl.js
+++ b/src/webgl.js
@@ -73,6 +73,9 @@ WebGLRenderer.prototype.destroy = function() {
 	gl.deleteProgram(this.loadingProgram);
 
 	gl.deleteBuffer(this.vertexBuffer);
+
+	gl.getExtension('WEBGL_lose_context').loseContext();
+	this.canvas.remove();
 };
 
 WebGLRenderer.prototype.resize = function(width, height) {


### PR DESCRIPTION
there is problem with resources when using jsmpeg to turn on/off multiple streaming instances.
troubleshooting done using chrome task manager and memory tab options. 

to release all GPU memory resources, it is necessary to manually lose webgl context. 
canvas element is also removed although not quite sure if this should be here or maybe somewhere else or this is maybe done by user manually? 

there is additional problem with 'memory footprint' which is present even after refreshing page - memory heap snapshot shows system/jsArrayBufferData taking lot of memory but not quite sure how to solve this