### PR TITLE
Fix timeout after 1 minute error on node >=v11.3 in websocket-relay

### DIFF
--- a/websocket-relay.js
+++ b/websocket-relay.js
@@ -27,7 +27,7 @@ socketServer.connectionCount = 0;
 socketServer.on('connection', function(socket, upgradeReq) {
 	socketServer.connectionCount++;
 	console.log(
-		'New WebSocket Connection: ', 
+		'New WebSocket Connection: ',
 		(upgradeReq || socket.upgradeReq).socket.remoteAddress,
 		(upgradeReq || socket.upgradeReq).headers['user-agent'],
 		'('+socketServer.connectionCount+' total)'
@@ -61,7 +61,7 @@ var streamServer = http.createServer( function(request, response) {
 
 	response.connection.setTimeout(0);
 	console.log(
-		'Stream Connected: ' + 
+		'Stream Connected: ' +
 		request.socket.remoteAddress + ':' +
 		request.socket.remotePort
 	);
@@ -83,7 +83,10 @@ var streamServer = http.createServer( function(request, response) {
 		var path = 'recordings/' + Date.now() + '.ts';
 		request.socket.recording = fs.createWriteStream(path);
 	}
-}).listen(STREAM_PORT);
+})
+// Keep the socket open for streaming
+streamServer.headersTimeout = 0;
+streamServer.listen(STREAM_PORT);
 
 console.log('Listening for incomming MPEG-TS Stream on http://127.0.0.1:'+STREAM_PORT+'/<secret>');
 console.log('Awaiting WebSocket connections on ws://127.0.0.1:'+WEBSOCKET_PORT+'/');


### PR DESCRIPTION
In node 11.3, `server.headersTimeout` was introduced which defaults to 60 seconds. From that node version on, the websocket-relay.js streamServer would timeout after these 60 seconds, and close the incoming ffmpeg stream. This leads to a `Error writing trailer of http://localhost:8081/supersecret: Broken pipe` error in Ffmpeg.
Setting headersTimeout to 0 solves this.